### PR TITLE
Turn `elseif` into `else if`

### DIFF
--- a/src/big-bang-parser/big_bang_lexer.mll
+++ b/src/big-bang-parser/big_bang_lexer.mll
@@ -66,32 +66,32 @@ rule read = parse
 
   (* Keywords. *)
 
-  | "true"    { TRUE }
-  | "false"   { FALSE }
-  | "and"     { AND }
-  | "or"      { OR }
-  | "xor"     { XOR }
-  | "not"     { NOT }
-  | "fun"     { FUN }
-  | "def"     { DEF }
-  | "let"     { LET }
-  | "ref"     { REF }
-  | "if"      { IF }
-  | "then"    { THEN }
-  | "elseif"  { ELSE_IF }
-  | "else"    { ELSE }
-  | "end"     { END }
-  | "match"   { MATCH }
-  | "as"      { AS }
-  | "in"      { IN }
-  | "repeat"  { REPEAT }
-  | "while"   { WHILE }
-  | "do"      { DO }
-  | "return"  { RETURN }
-  | "object"  { OBJECT }
-  | "include" { INCLUDE }
-  | "public"  { PUBLIC }
-  | "private" { PRIVATE }
+  | "true"                 { TRUE }
+  | "false"                { FALSE }
+  | "and"                  { AND }
+  | "or"                   { OR }
+  | "xor"                  { XOR }
+  | "not"                  { NOT }
+  | "fun"                  { FUN }
+  | "def"                  { DEF }
+  | "let"                  { LET }
+  | "ref"                  { REF }
+  | "if"                   { IF }
+  | "then"                 { THEN }
+  | "else" whitespace "if" { ELSE_IF }
+  | "else"                 { ELSE }
+  | "end"                  { END }
+  | "match"                { MATCH }
+  | "as"                   { AS }
+  | "in"                   { IN }
+  | "repeat"               { REPEAT }
+  | "while"                { WHILE }
+  | "do"                   { DO }
+  | "return"               { RETURN }
+  | "object"               { OBJECT }
+  | "include"              { INCLUDE }
+  | "public"               { PUBLIC }
+  | "private"              { PRIVATE }
 
   (* Literals. *)
 


### PR DESCRIPTION
For readability purposes, I'd like to turn the `elseif` keyword into `else if`. Previously me and @zepalmer thought about how to handle that on the parser, which as kind of difficult and not worth the effort. But then I had this idea of doing it on the lexer, which should be fine.

I guess I could allow for newlines (in addition to whitespace) separating the words `else` and `if`, but I think this could actually hurt readability instead of improving it. Therefore, my proposal is to have `else if` being a keyword if they are on the same line.

I talked with @phsmenon and he was neutral about the idea. @rpglover64, @zepalmer, what do you think?
