### PR TITLE
Add ref cells to {little, big} bang

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -153,7 +153,9 @@ Library "big-bang-translator"
     big-bang-ast,
     little-bang-ast,
     tiny-bang-ast,
-    tiny-bang-utils
+    tiny-bang-utils,
+    little-bang-parser
+  DataFiles: src/big-bang-translator/prelude.lb
 
 Executable "tiny-bang-toploop"
   Path: src/tiny-bang-toploop

--- a/src/big-bang-translator/prelude.lb
+++ b/src/big-bang-translator/prelude.lb
@@ -1,0 +1,4 @@
+let $variableUnwrap = (fun ref $variableUnwrap_ref -> $variableUnwrap_ref) & (fun $variableUnwrap_other -> $variableUnwrap_other) in
+
+BIG_BANG_COMPILATION_UNIT
+

--- a/src/little-bang-ast/little_bang_ast.ml
+++ b/src/little-bang-ast/little_bang_ast.ml
@@ -32,6 +32,9 @@ type pattern =
   | Var_pattern of ast_uid * var
   | Empty_pattern of ast_uid
   | Label_pattern of ast_uid * label * pattern
+  | Ref_pattern of ast_uid * pattern
+  | Int_pattern of ast_uid * pattern
+  | Array_pattern of ast_uid * pattern
   | Conjunction_pattern of ast_uid * pattern * pattern
 ;;
 
@@ -43,6 +46,11 @@ type expr =
   | Let_expr of ast_uid * var * expr * expr
   | Appl_expr of ast_uid * expr * expr
   | Builtin_expr of ast_uid * Tiny_bang_ast.builtin_op * expr list
+  (* This is an expression in little bang, but a value in tiny bang.
+     The reason why is that Ref_value in tiny bang requires a var,
+     while Ref_expr in little bang takes an expression, so it needs to
+     be able to add clauses, so it can't just be a litle bang value.*)
+  | Ref_expr of ast_uid * expr
 and value =
   | Empty_onion of ast_uid
   | Function of ast_uid * pattern * expr

--- a/src/little-bang-parser/little_bang_generated_lexer.mll
+++ b/src/little-bang-parser/little_bang_generated_lexer.mll
@@ -8,8 +8,8 @@ let whitespace = [' ' '\t' '\n']
 let comment = '#' [^'\n']* '\n'
 let integer = '-'? ('0' | ['1'-'9'] (digit | '_')*)
 
-let ident_start = alpha
-let ident_cont = alpha | digit
+let ident_start = '_' | alpha | '$' (*$ identifiers are for internal identifiers*)
+let ident_cont = '_' | alpha | digit
 
 rule token = parse
   | eof                              { EOF }
@@ -29,6 +29,14 @@ rule token = parse
   | "fun"                            { KEYWORD_FUN }
   | "let"                            { KEYWORD_LET }
   | "in"                             { KEYWORD_IN }
+  | "ref"                            { KEYWORD_REF }
+  | "int"                            { KEYWORD_INT }
+  | "array"                          { KEYWORD_ARRAY }
+  | "arrayNew"                       { KEYWORD_ARRAY_NEW }
+  | "arrayGet"                       { KEYWORD_ARRAY_GET }
+  | "arraySet"                       { KEYWORD_ARRAY_SET }
+  | "arrayLength"                    { KEYWORD_ARRAY_LENGTH }
+  | ":"                              { COLON }
   | ident_start ident_cont* as s     { IDENTIFIER s }
   | "`" (ident_cont* as s)           { LABEL s }
   | integer as s                     { INT (int_of_string (s)) }

--- a/src/tiny-bang-interpreter/tiny_bang_interpreter.ml
+++ b/src/tiny-bang-interpreter/tiny_bang_interpreter.ml
@@ -107,9 +107,8 @@ let rec application_match env x_fn x_arg : clause list option =
   logger `debug ("Lookup: " ^ pretty_var x_fn ^ "\n");
   match lookup env x_fn with
   | Onion_value(_, x_left, x_right) ->
-    Option.map_default Option.some
-      (application_match env x_left x_arg)
-      (application_match env x_right x_arg)
+    BatEnum.peek @@
+      BatEnum.append (BatOption.enum @@ application_match env x_left x_arg) (BatOption.enum @@ application_match env x_right x_arg)
   | Function_value(_, pat, Expr(_, cls)) ->
     begin
       let answer = compatibility env x_arg pat in

--- a/src/tiny-bang-typechecker/tiny_bang_constraint_closure.ml
+++ b/src/tiny-bang-typechecker/tiny_bang_constraint_closure.ml
@@ -295,7 +295,7 @@ let builtin_closure op =
               Enum.singleton @@ Inconsistency_constraint
         end
     | Op_array_set -> fun (cs : Constraint_database.t) ->
-      close_primitive_builtin cs Op_array_get @@ fun upper_bound operands ->
+      close_primitive_builtin cs Op_array_set @@ fun upper_bound operands ->
         begin
           match operands with
           | [Filtered_type(Array_type contents,_,_); Filtered_type(Int_type,_,_); newValue] ->


### PR DESCRIPTION
This adds refs to big bang.

Example:

```
ref x = 5;
x = 6;
x;;
__1 where { __1 = ref __2, __2 = 6, x = ref __2, __3 = ref __2, __4 = 6, __0 = () }
```
#13 is a problem that ought to be fixed, which is related to this PR.

Reviewers: @leafac @rpglover64 @zepalmer
