### PR TITLE
Add little bang variable shadowing

### DIFF
--- a/src/big-bang-translator/big_bang_translator.ml
+++ b/src/big-bang-translator/big_bang_translator.ml
@@ -23,14 +23,14 @@ let translate_identifier (identifier : Big_bang_ast.identifier) : Little_bang_as
     Little_bang_ast.Fresh_ident identifier_id
 ;;
 
-let translate_identifier_to_tiny_bang
+let translate_identifier_to_tiny_bang_label
     (identifier : Big_bang_ast.identifier)
-  : Tiny_bang_ast.ident =
-  match identifier with
+  : Tiny_bang_ast.label =
+  Tiny_bang_ast.Label (match identifier with
   | Big_bang_ast.Identifier identifier_string ->
     Tiny_bang_ast.Ident identifier_string
   | Big_bang_ast.Fresh_identifier identifier_id ->
-    Tiny_bang_ast.Fresh_ident identifier_id
+    Tiny_bang_ast.Fresh_ident (identifier_id, None))
 ;;
 
 let rec translate_program (program : Big_bang_ast.program) : Little_bang_ast.expr =
@@ -273,9 +273,7 @@ and translate_pattern_literal (pattern_literal : Big_bang_ast.pattern_literal) :
       fun (identifier, pattern) ->
         Little_bang_ast.Label_pattern (
           Tiny_bang_ast_uid.next_uid (),
-          Tiny_bang_ast.Label (
-            translate_identifier_to_tiny_bang identifier
-          ),
+        translate_identifier_to_tiny_bang_label identifier,
           translate_pattern pattern
         )
     )
@@ -405,9 +403,7 @@ and translate_literal (literal : Big_bang_ast.literal) : Little_bang_ast.expr =
       fun (identifier, expression) ->
         Little_bang_ast.Label_expr (
           Tiny_bang_ast_uid.next_uid (),
-          Tiny_bang_ast.Label (
-            translate_identifier_to_tiny_bang identifier
-          ),
+          translate_identifier_to_tiny_bang_label identifier,
           translate_expression expression
         )
     )
@@ -729,9 +725,7 @@ and translate_object_member (object_member : Big_bang_ast.object_member) : Littl
             ),
             Little_bang_ast.Label_pattern (
               Tiny_bang_ast_uid.next_uid (),
-              Tiny_bang_ast.Label (
-                translate_identifier_to_tiny_bang message
-              ),
+              translate_identifier_to_tiny_bang_label message,
               Little_bang_ast.Empty_pattern (
                 Tiny_bang_ast_uid.next_uid ()
               )

--- a/src/little-bang-ast/little_bang_ast.ml
+++ b/src/little-bang-ast/little_bang_ast.ml
@@ -14,7 +14,10 @@ type ident =
 
 let new_fresh_ident () =
   match Tiny_bang_ast.new_fresh_ident () with
-  | Tiny_bang_ast.Fresh_ident n -> Fresh_ident n
+  | Tiny_bang_ast.Fresh_ident(n, _) ->
+        (*We're really only using this code to get at the number-generation
+         * scheme, so we can ignore any labels.*)  
+        Fresh_ident n
   | Tiny_bang_ast.Ident _ ->
     raise @@ Invariant_failure
       "Tiny_bang_ast.new_fresh_ident returned Ident (not Fresh_ident)"

--- a/src/tiny-bang-ast/tiny_bang_ast.ml
+++ b/src/tiny-bang-ast/tiny_bang_ast.ml
@@ -28,7 +28,8 @@ type builtin_op =
 (** A data type for identifiers in TinyBang. *)
 type ident =
   | Ident of string
-  | Fresh_ident of int
+  | Fresh_ident of int * string option (* this string is a label for debugging
+                                        purposes. It's printed if it's present. *)
   | Builtin_ident of builtin_op * int
   | Builtin_local_ident of builtin_op * ident * int
 ;;
@@ -54,10 +55,16 @@ module Ident_set = Set.Make(Ident_order);;
 
 let fresh_ident_counter = ref 0;;
 
+let new_labeled_fresh_ident label =
+  let current_fresh_ident = !fresh_ident_counter in
+  fresh_ident_counter := current_fresh_ident + 1;
+  Fresh_ident (current_fresh_ident, Some label)
+;;
+
 let new_fresh_ident () =
   let current_fresh_ident = !fresh_ident_counter in
   fresh_ident_counter := current_fresh_ident + 1;
-  Fresh_ident current_fresh_ident
+  Fresh_ident (current_fresh_ident, None)
 ;;
 
 (** The label type.  The identifier stored in this label does not contain the

--- a/src/tiny-bang-ast/tiny_bang_ast_pretty.ml
+++ b/src/tiny-bang-ast/tiny_bang_ast_pretty.ml
@@ -20,7 +20,8 @@ let pretty_builtin_op op =
 let rec pretty_ident ident =
   match ident with
   | Ident s -> s
-  | Fresh_ident id -> "__" ^ string_of_int id
+  | Fresh_ident (id, None) -> "__" ^ string_of_int id
+  | Fresh_ident (id, Some label) -> label ^ "__" ^ string_of_int id
   | Builtin_ident(op,n) -> "__" ^ pretty_builtin_op op ^ "_" ^ string_of_int n
   | Builtin_local_ident(op,basis,n) -> "__" ^ pretty_builtin_op op ^ "__based_on__" ^ (pretty_ident basis) ^ "__" ^ string_of_int n
 ;;

--- a/test/test_little_bang_a_translator.ml
+++ b/test/test_little_bang_a_translator.ml
@@ -30,7 +30,9 @@ let test_expression_empty_onion _ =
   in
   assert_bool "expected A-Translation to return the empty onion" (
     is_expected_tiny_bang_expression (
-      Little_bang_a_translator.a_translate_expr little_bang_expression binding_ident
+      Little_bang_a_translator.a_translate_expr
+        Little_bang_a_translator.Ident_map.empty
+        little_bang_expression binding_ident
     )
   )
 ;;
@@ -85,7 +87,9 @@ let test_expression_label _ =
   in
   assert_bool "expected A-Translation to return the label expression" (
     is_expected_tiny_bang_expression (
-      Little_bang_a_translator.a_translate_expr little_bang_expression binding_ident
+      Little_bang_a_translator.a_translate_expr
+        Little_bang_a_translator.Ident_map.empty
+        little_bang_expression binding_ident
     )
   )
 ;;
@@ -153,7 +157,7 @@ let test_expression_onion _ =
   in
   assert_bool "expected A-Translation to return the onion" (
     is_expected_tiny_bang_expression (
-      Little_bang_a_translator.a_translate_expr little_bang_expression binding_ident
+      Little_bang_a_translator.a_translate_expr Little_bang_a_translator.Ident_map.empty little_bang_expression binding_ident
     )
   )
 ;;
@@ -210,7 +214,7 @@ let test_expression_function _ =
   in
   assert_bool "expected A-Translation to return the function" (
     is_expected_tiny_bang_expression (
-      Little_bang_a_translator.a_translate_expr little_bang_expression binding_ident
+      Little_bang_a_translator.a_translate_expr Little_bang_a_translator.Ident_map.empty little_bang_expression binding_ident
     )
   )
 ;;
@@ -298,7 +302,7 @@ let test_expression_appl _ =
   in
   assert_bool "expected A-Translation to return the appl" (
     is_expected_tiny_bang_expression (
-      Little_bang_a_translator.a_translate_expr little_bang_expression binding_ident
+      Little_bang_a_translator.a_translate_expr Little_bang_a_translator.Ident_map.empty little_bang_expression binding_ident
     )
   )
 ;;
@@ -349,7 +353,9 @@ let test_expression_let _ =
           )
         ]
       ) ->
-      assert_equal (Little_bang_a_translator.a_translate_ident assigned_ident)
+      assert_equal (Little_bang_a_translator.a_translate_ident
+        (Little_bang_a_translator.Ident_map.singleton assigned_ident assigned_ident_output)
+        assigned_ident)
         assigned_ident_output;
       assert_equal binding_ident binding_ident_output;
       true
@@ -357,7 +363,7 @@ let test_expression_let _ =
   in
   assert_bool "expected A-Translation to return the let" (
     is_expected_tiny_bang_expression (
-      Little_bang_a_translator.a_translate_expr little_bang_expression binding_ident
+      Little_bang_a_translator.a_translate_expr Little_bang_a_translator.Ident_map.empty little_bang_expression binding_ident
     )
   )
 ;;
@@ -394,7 +400,7 @@ let test_expression_var _ =
           )
         ]
       ) ->
-      assert_equal (Little_bang_a_translator.a_translate_ident var_ident)
+      assert_equal (Little_bang_a_translator.a_translate_ident Little_bang_a_translator.Ident_map.empty var_ident)
         var_ident_output;
       assert_equal binding_ident binding_ident_output;
       true
@@ -402,7 +408,7 @@ let test_expression_var _ =
   in
   assert_bool "expected A-Translation to return the var" (
     is_expected_tiny_bang_expression (
-      Little_bang_a_translator.a_translate_expr little_bang_expression binding_ident
+      Little_bang_a_translator.a_translate_expr Little_bang_a_translator.Ident_map.empty little_bang_expression binding_ident
     )
   )
 ;;
@@ -412,10 +418,10 @@ let test_pattern_empty_onion _ =
   let little_bang_pattern =
     Little_bang_ast.Empty_pattern (Tiny_bang_ast_uid.next_uid ())
   in
-  match Little_bang_a_translator.a_translate_pattern little_bang_pattern binding_ident with
-  | Tiny_bang_ast.Pattern (
+  match Little_bang_a_translator.a_translate_pattern Little_bang_a_translator.Ident_map.empty little_bang_pattern binding_ident with
+  | (Tiny_bang_ast.Pattern (
       _, (Tiny_bang_ast.Pvar (_, binding_ident_output)), tiny_bang_pattern_filter_rules
-    ) ->
+    ), _) ->
     assert_equal binding_ident binding_ident_output;
     (
       match Tiny_bang_ast.Pvar_map.bindings tiny_bang_pattern_filter_rules with
@@ -440,10 +446,10 @@ let test_pattern_label _ =
       (Little_bang_ast.Empty_pattern (Tiny_bang_ast_uid.next_uid ()))
     )
   in
-  match Little_bang_a_translator.a_translate_pattern little_bang_pattern binding_ident with
-  | Tiny_bang_ast.Pattern (
+  match Little_bang_a_translator.a_translate_pattern Little_bang_a_translator.Ident_map.empty little_bang_pattern binding_ident with
+  | (Tiny_bang_ast.Pattern (
       _, (Tiny_bang_ast.Pvar (_, binding_ident_output)), tiny_bang_pattern_filter_rules
-    ) ->
+    ), _) ->
     assert_equal binding_ident binding_ident_output;
     (
       match Tiny_bang_ast.Pvar_map.bindings tiny_bang_pattern_filter_rules with
@@ -476,10 +482,10 @@ let test_pattern_conjunction _ =
       (Little_bang_ast.Empty_pattern (Tiny_bang_ast_uid.next_uid ()))
     )
   in
-  match Little_bang_a_translator.a_translate_pattern little_bang_pattern binding_ident with
-  | Tiny_bang_ast.Pattern (
+  match Little_bang_a_translator.a_translate_pattern Little_bang_a_translator.Ident_map.empty little_bang_pattern binding_ident with
+  | (Tiny_bang_ast.Pattern (
       _, (Tiny_bang_ast.Pvar (_, binding_ident_output)), tiny_bang_pattern_filter_rules
-    ) ->
+    ), _) ->
     assert_equal binding_ident binding_ident_output;
     (
       match Tiny_bang_ast.Pvar_map.bindings tiny_bang_pattern_filter_rules with
@@ -520,10 +526,10 @@ let test_pattern_var _ =
       )
     )
   in
-  match Little_bang_a_translator.a_translate_pattern little_bang_pattern binding_ident with
-  | Tiny_bang_ast.Pattern (
+  match Little_bang_a_translator.a_translate_pattern Little_bang_a_translator.Ident_map.empty little_bang_pattern binding_ident with
+  | (Tiny_bang_ast.Pattern (
       _, (Tiny_bang_ast.Pvar (_, binding_ident_output)), tiny_bang_pattern_filter_rules
-    ) ->
+    ), _) ->
     assert_equal binding_ident binding_ident_output;
     (
       match Tiny_bang_ast.Pvar_map.bindings tiny_bang_pattern_filter_rules with


### PR DESCRIPTION
This adds little bang variable shadowing, and prevents naming conflicts.

Note that there is one test case that is still failing. @zepalmer: why are we using conjunction patterns for converting little bang variable patterns to tiny bang patterns?

@zepalmer @leafac @rpglover64 @phsmenon 
